### PR TITLE
Fix npm install failure with latest bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "async": "~0.2.10",
-    "bower": "~1.0.0",
+    "bower": "~1.3.12",
     "extfs": "0.0.7",
     "lodash": "~1.3.1",
     "minimatch": "~0.2.14",


### PR DESCRIPTION
``` shell
npm install bower-clean
npm ERR! Darwin 13.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "install" "bower-clean"
npm ERR! node v0.10.32
npm ERR! npm  v2.1.3
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: bower-config@'>=0.2.0 <0.3.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.1.0-rc.1","0.1.0-rc.2","0.1.0-rc.3","0.1.0-rc.4","0.1.0-rc.5","0.2.0-rc.1","0.2.0-rc.2","0.3.0","0.3.1","0.3.3","0.3.4","0.3.5","0.4.0","0.4.1","0.4.2","0.4.3","0.4.4","0.4.5","0.5.0","0.5.1","0.5.2"]
npm ERR! notarget
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/serg/Develop/testt/npm-debug.log
```
